### PR TITLE
Skip loading table ‚ar_internal_metadata‘

### DIFF
--- a/lib/serialization_helper.rb
+++ b/lib/serialization_helper.rb
@@ -79,6 +79,7 @@ module SerializationHelper
     end
 
     def self.load_table(table, data, truncate = true)
+      return if table == 'ar_internal_metadata'
       column_names = data['columns']
       if truncate
         truncate_table(table)


### PR DESCRIPTION
Rails 5 seems to do something magically in some environments, see http://blog.bigbinary.com/2016/06/07/rails-5-prevents-destructive-action-on-production-db.html

This leads to errors with data_sync as the table is not created via schema:load (I guess)